### PR TITLE
Wrong version number in README.md for responsive image

### DIFF
--- a/bundles/core/src/main/webapp/app-root/components/wcmio/responsiveimage/v1/README.md
+++ b/bundles/core/src/main/webapp/app-root/components/wcmio/responsiveimage/v1/README.md
@@ -1,4 +1,4 @@
-wcm.io Responsive Image (v2)
+wcm.io Responsive Image (v1)
 ====
 Image component written in HTL that renders an responsive image using standard HTML5 markup.
 
@@ -9,11 +9,11 @@ wcm-io/wcm/core/components/wcmio/responsiveimage/v1/responsiveimage
 
 ## Features
 
-* Markup and features are similar to the [Image Core Component][image-component], except the image element itself.
+* Markup and features are similar to the [Image Core Component][image-component], except the image element itself
 * Uses [wcm.io Media Handler][wcmio-handler-media] for processing the image
 * Allows to select media format(s) and auto-cropping in the content policy
 * Allows to define responsive image settings in the content policy, allowing to select between image element with sizes and srcset attributes, or picture and sources elements
-* Automatically customizes the in-place image editor cropping ratios to  the selected/the applications media formats
+* Automatically customizes the in-place image editor cropping ratios to the selected/the application's media formats
 * Uses the enhanced Media Handler File Upload dialog widget with path field and media format validation
 * Uses [wcm.io Link Handler][wcmio-handler-link] for processing the image link
 * Uses the Link Handler dialog widget for defining link type and link target


### PR DESCRIPTION
The README.md is stating a wrong version number.

I don't know if it slipped through due to merging back and forth while preparing for v2 or something similar and if other parts are also affected.