### PR TITLE
Escape html characters of description from page for teaser

### DIFF
--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -186,6 +186,12 @@
       <scope>compile</scope>
     </dependency>
 
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-text</artifactId>
+        <scope>compile</scope>
+      </dependency>
+
     <!-- For build compatibility with Java 11 -->
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>

--- a/bundles/core/src/main/java/io/wcm/wcm/core/components/impl/models/v1/TeaserImpl.java
+++ b/bundles/core/src/main/java/io/wcm/wcm/core/components/impl/models/v1/TeaserImpl.java
@@ -30,6 +30,7 @@ import java.util.List;
 import javax.annotation.PostConstruct;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
@@ -175,6 +176,8 @@ public class TeaserImpl extends AbstractComponentImpl implements Teaser, MediaMi
       if (descriptionFromPage) {
         if (targetPage != null) {
           description = targetPage.getDescription();
+          // page description is by default no rich text
+          description = StringEscapeUtils.escapeHtml4(description);
         }
       }
       else {

--- a/bundles/core/src/test/java/io/wcm/wcm/core/components/impl/models/v1/TeaserImplTest.java
+++ b/bundles/core/src/test/java/io/wcm/wcm/core/components/impl/models/v1/TeaserImplTest.java
@@ -194,6 +194,26 @@ class TeaserImplTest {
     assertEquals("Page Title", underTest.getTitle());
     assertEquals("Page Description", underTest.getDescription());
   }
+  
+  @Test
+  void testTitleDescriptionFromPage_HtmlReservedChars() {
+    Page targetPage = context.create().page(page, "page1", null,
+        JCR_TITLE, "Page Title",
+        JCR_DESCRIPTION, "<&& cool page description &&>");
+    context.currentResource(context.create().resource(page, "teaser",
+        PROPERTY_RESOURCE_TYPE, RESOURCE_TYPE,
+        JCR_TITLE, "Teaser Title",
+        JCR_DESCRIPTION, "Teaser Description",
+        PN_LINK_TYPE, InternalLinkType.ID,
+        PN_LINK_CONTENT_REF, targetPage.getPath(),
+        PN_TITLE_FROM_PAGE, true,
+        PN_DESCRIPTION_FROM_PAGE, true));
+
+    Teaser underTest = AdaptTo.notNull(context.request(), Teaser.class);
+
+    assertEquals("Page Title", underTest.getTitle());
+    assertEquals("&lt;&amp;&amp; cool page description &amp;&amp;&gt;", underTest.getDescription());
+  }
 
   @Test
   void testTitleDescriptionFromPage_NotEnabled() {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -187,7 +187,12 @@
         <artifactId>jsonassert</artifactId>
         <version>1.5.0</version>
       </dependency>
-    
+
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-text</artifactId>
+        <version>1.9</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
When a teaser receives the description from the page, html characters are escaped.

Normally the page description page contains no rich text. But the author can add reserved html characters to the page description, like ‘&’.  This result that null is returned by the RichTextHandler. So the special characters must be escaped when the description is loaded from the page properties.
I had to add commons-text as a dependency, because StringEscapeUtils in commons-lang3 is deprecated. If there are other libraries for this task already given, the code can be changed to them.
